### PR TITLE
Reworked src/image to unload textures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,7 +2303,7 @@ checksum = "4ccbe8381883510b6a2d8f1e32905bddd178c11caef8083086d0c0c9ab0ac281"
 
 [[package]]
 name = "twitter_client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "dotenv",
@@ -2317,6 +2317,7 @@ dependencies = [
  "lazy_static",
  "log",
  "open",
+ "parking_lot",
  "pretty_env_logger",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,27 +1,28 @@
 [package]
 name = "twitter_client"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "EUPL"
 
 [dependencies]
-bytes = "1.1.0"
-dotenv = "0.15.0"
-egg-mode = "0.16.0"
-egui = "0.16.1"
-egui_glium = "0.16.0"
-epi = "0.16.0"
-futures = "0.3.19"
-glium = "0.31.0"
-image = "0.23.14"
-lazy_static = "1.4.0"
-log = "0.4.14"
-open = "2.0.2"
-pretty_env_logger = "0.4.0"
-reqwest = { version = "0.11.9", features = ["json"] }
-serde = { version = "1.0.133", features = ["derive"] }
-tokio = { version = "1.15.0", features = ["time", "macros"] }
-toml = "0.5.8"
+bytes = "1.1"
+dotenv = "0.15"
+egg-mode = "0.16"
+egui = "0.16"
+egui_glium = "0.16"
+epi = "0.16"
+futures = "0.3"
+glium = "0.31"
+image = "0.23"
+lazy_static = "1.4"
+log = "0.4"
+open = "2.0"
+parking_lot = "0.11"
+pretty_env_logger = "0.4"
+reqwest = { version = "0.11", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.15", features = ["time", "macros"] }
+toml = "0.5"
 
 [build-dependencies]
-dotenv = "0.15.0"
+dotenv = "0.15"

--- a/src/image.rs
+++ b/src/image.rs
@@ -2,12 +2,11 @@ use bytes::Bytes;
 use egui::TextureId;
 use image::{self, GenericImageView, ImageFormat};
 use lazy_static::lazy_static;
-use std::sync::{Arc, Mutex};
-use std::{
-    cell::UnsafeCell,
-    collections::{hash_map::Entry, HashMap},
-    sync::atomic::{AtomicBool, Ordering},
-};
+use parking_lot::{Mutex, RwLock};
+use std::cell::Cell;
+use std::collections::{hash_map::Entry, HashMap};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 const TARGET: &str = "Image";
 
@@ -16,74 +15,114 @@ pub enum Key {
     Https(String),
 }
 
-pub struct LoadContext {
-    loaded: AtomicBool,
-    result: UnsafeCell<Result<TextureId, String>>,
-}
+#[derive(Clone)]
+pub struct LoadContext(Arc<Inner>);
 
 impl Default for LoadContext {
     fn default() -> Self {
-        Self {
-            loaded: AtomicBool::new(false),
-            result: UnsafeCell::new(Err(String::new())),
-        }
+        Self(Arc::new(Inner {
+            result: RwLock::default(),
+            last_access: Cell::new(Instant::now()),
+        }))
     }
 }
 
 impl LoadContext {
+    fn accessed(&self) {
+        self.0.last_access.set(Instant::now());
+    }
+
     fn set_error(&self, e: impl Into<String>) {
-        let ptr = self.result.get();
-        unsafe {
-            *ptr = Err(e.into());
-        }
-        self.loaded.store(true, Ordering::SeqCst);
+        self.accessed();
+        *self.0.result.write() = LoadingStatus::Error(e.into());
     }
     fn set_texture_id(&self, id: TextureId) {
-        let ptr = self.result.get();
-        unsafe {
-            *ptr = Ok(id);
-        }
-        self.loaded.store(true, Ordering::SeqCst);
+        self.accessed();
+        *self.0.result.write() = LoadingStatus::Loaded(id);
     }
 
     pub fn get_texture_id(&self) -> Option<TextureId> {
-        if self.loaded.load(Ordering::Relaxed) {
-            unsafe { &*self.result.get() }.as_ref().ok().copied()
-        } else {
-            None
-        }
+        self.accessed();
+        self.0.result.read().as_texture()
     }
-    pub fn get_error(&self) -> Option<&str> {
-        if self.loaded.load(Ordering::Relaxed) {
-            unsafe { &*self.result.get() }
-                .as_ref()
-                .err()
-                .map(|s| s.as_str())
-        } else {
-            None
-        }
+
+    pub fn get_error(&self) -> Option<String> {
+        self.accessed();
+        self.0.result.read().as_error()
     }
 }
 
 impl std::fmt::Debug for LoadContext {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-        fmt.debug_struct("LoadContext")
-            .field("loaded", &self.loaded)
-            .finish_non_exhaustive()
+        let mut dbg = fmt.debug_struct("LoadContext");
+        let read = self.0.result.read();
+        if read.is_loading() {
+            dbg.field("loading", &true);
+        } else if let Some(id) = read.as_texture() {
+            dbg.field("texture_id", &id);
+        } else if let Some(e) = read.as_error() {
+            dbg.field("error", &e);
+        }
+
+        dbg.finish_non_exhaustive()
     }
 }
 
-unsafe impl Sync for LoadContext {}
+struct Inner {
+    result: RwLock<LoadingStatus>,
+    last_access: Cell<Instant>,
+}
 
+unsafe impl Sync for Inner {}
+
+enum LoadingStatus {
+    Loading,
+    Loaded(TextureId),
+    Error(String),
+}
+
+impl Default for LoadingStatus {
+    fn default() -> Self {
+        Self::Loading
+    }
+}
+
+impl LoadingStatus {
+    fn is_loading(&self) -> bool {
+        matches!(self, Self::Loading)
+    }
+
+    fn as_error(&self) -> Option<String> {
+        match self {
+            Self::Error(s) => Some(s.clone()),
+            _ => None,
+        }
+    }
+
+    fn as_texture(&self) -> Option<TextureId> {
+        match self {
+            Self::Loaded(id) => Some(*id),
+            _ => None,
+        }
+    }
+}
 pub struct ToUIImage {
     key: Key,
-    context: Arc<LoadContext>,
+    context: LoadContext,
     image: epi::Image,
 }
 
 impl ToUIImage {
     pub fn finish_load(self, frame: &mut epi::Frame) {
         let texture = frame.alloc_texture(self.image);
+        log::info!(
+            target: TARGET,
+            "Id is {}",
+            match &texture {
+                TextureId::User(id) => id,
+                _ => unreachable!(),
+            }
+        );
         self.context.set_texture_id(texture);
     }
 }
@@ -97,7 +136,7 @@ impl std::fmt::Debug for ToUIImage {
     }
 }
 
-pub async fn load_image_async(key: Key, context: Arc<LoadContext>) -> Option<ToUIImage> {
+pub async fn load_image_async(key: Key, context: LoadContext) -> Option<ToUIImage> {
     log::info!(target: TARGET, "Loading {:?}", key);
     let (bytes, format): (Bytes, Option<ImageFormat>) = match &key {
         Key::Https(url) => {
@@ -154,17 +193,47 @@ pub async fn load_image_async(key: Key, context: Arc<LoadContext>) -> Option<ToU
 }
 
 lazy_static! {
-    static ref CACHE: Mutex<HashMap<Key, Arc<LoadContext>>> = Mutex::default();
+    static ref LAST_CLEANUP_TIME: Mutex<Option<Instant>> = Mutex::default();
+    static ref CACHE: Mutex<HashMap<Key, LoadContext>> = Mutex::default();
 }
 
-pub fn get_context(key: Key) -> Arc<LoadContext> {
-    let mut lock = CACHE.lock().unwrap();
+pub fn get_context(key: Key) -> LoadContext {
+    let mut lock = CACHE.lock();
     match lock.entry(key) {
-        Entry::Occupied(o) => Arc::clone(o.get()),
+        Entry::Occupied(o) => o.get().clone(),
         Entry::Vacant(v) => {
-            let context = Arc::new(LoadContext::default());
-            crate::background::start_loading_image(v.key().clone(), Arc::clone(&context));
-            Arc::clone(v.insert(context))
+            let context = LoadContext::default();
+            crate::background::start_loading_image(v.key().clone(), context.clone());
+            v.insert(context).clone()
+        }
+    }
+}
+
+pub fn cleanup(frame: &epi::Frame) {
+    let mut keys_to_remove = Vec::new();
+    let mut write = CACHE.lock();
+    for (key, ctx) in write.iter_mut() {
+        if ctx.0.last_access.get().elapsed() > Duration::from_secs(60) {
+            keys_to_remove.push(key.clone());
+        }
+    }
+
+    for key in keys_to_remove {
+        let val = write.remove(&key).unwrap();
+        let inner = match Arc::try_unwrap(val.0) {
+            Ok(inner) => inner,
+            Err(_) => {
+                log::warn!(
+                    target: TARGET,
+                    "Could not clean up texture; in use somewhere"
+                );
+                continue;
+            }
+        };
+        let read = inner.result.read();
+        if let Some(id) = read.as_texture() {
+            log::debug!(target: TARGET, "Cleaning up {:?}", id);
+            frame.free_texture(id);
         }
     }
 }

--- a/src/ui/utils/image.rs
+++ b/src/ui/utils/image.rs
@@ -1,10 +1,8 @@
-use egui::{Vec2, Widget};
-use std::sync::Arc;
-
 use crate::image::{self, Key, LoadContext};
+use egui::{Vec2, Widget};
 
 pub struct Image {
-    context: Arc<LoadContext>,
+    context: LoadContext,
     size: Vec2,
 }
 


### PR DESCRIPTION
Textures are now unloaded if they're not used for a minute.

Also reworked the internals of `image;:LoadContext` so it doesn't have to be wrapped in an `Arc` and got rid of all of the `UnsafeCell`s